### PR TITLE
supress exception messages on ruby 2.5

### DIFF
--- a/lib/takuhai_status.rb
+++ b/lib/takuhai_status.rb
@@ -25,6 +25,7 @@ module TakuhaiStatus
 		[].tap{|threads|
 			[Sagawa, JapanPost, KuronekoYamato, TMGCargo, UPS, FedEx].each do |service|
 				threads.push(Thread.new{
+					Thread.current.report_on_exception = false
 					name = service.to_s.sub(/^.*::/, '')
 					begin
 						Timeout.timeout(timeout, Timeout::Error) do


### PR DESCRIPTION
ruby 2.5から`Thread.report_on_exception`がデフォルトで`true`になっており、`TakuhaiStatus.scan`の内部で発生する例外がすべて`$stderr`に表示されてしまっていた。これらの例外はThreadの外で捕捉されるので、表示を抑制する。