### PR TITLE
return NotMyKey error when key has invalid format

### DIFF
--- a/lib/takuhai_status/japanpost.rb
+++ b/lib/takuhai_status/japanpost.rb
@@ -7,7 +7,8 @@ module TakuhaiStatus
 		TakuhaiStatus.add_service(self)
 
 		def initialize(key)
-			@key = key.gsub(/[^a-zA-Z0-9]/, '')
+			@key = key.strip
+			raise NotMyKey.new('invalid key format') unless @key =~ /\A[a-zA-Z0-9]+\Z/
 			@time, @state = check
 		end
 

--- a/lib/takuhai_status/kuronekoyamato.rb
+++ b/lib/takuhai_status/kuronekoyamato.rb
@@ -7,7 +7,8 @@ module TakuhaiStatus
 		TakuhaiStatus.add_service(self)
 
 		def initialize(key)
-			@key = key.gsub(/[^0-9]/, '')
+			@key = key.strip
+			raise NotMyKey.new('invalid key format') unless @key =~ /\A[0-9]+\Z/
 			@time, @state = check
 		end
 

--- a/lib/takuhai_status/sagawa.rb
+++ b/lib/takuhai_status/sagawa.rb
@@ -7,7 +7,8 @@ module TakuhaiStatus
 		TakuhaiStatus.add_service(self)
 
 		def initialize(key)
-			@key = key.gsub(/[^0-9]/, '')
+			@key = key.strip
+			raise NotMyKey.new('invalid key format') unless @key =~ /\A[0-9]+\Z/
 			@time, @state = check
 		end
 

--- a/lib/takuhai_status/tmg_cargo.rb
+++ b/lib/takuhai_status/tmg_cargo.rb
@@ -9,7 +9,8 @@ module TakuhaiStatus
 		@@conn = nil
 
 		def initialize(key)
-			@key = key.gsub(/[^0-9]/, '')
+			@key = key.strip
+			raise NotMyKey.new('invalid key format') unless @key =~ /\A[0-9]+\Z/
 			@time, @state = check
 		end
 

--- a/lib/takuhai_status/ups.rb
+++ b/lib/takuhai_status/ups.rb
@@ -9,7 +9,8 @@ module TakuhaiStatus
 		@@conn = nil
 
 		def initialize(key)
-			@key = key.gsub(/[^a-zA-Z0-9]/, '')
+			@key = key.strip
+			raise NotMyKey.new('invalid key format') unless @key =~ /\A[a-zA-Z0-9]+\Z/
 			@time, @state = check
 		end
 

--- a/lib/takuhai_status/usps.rb
+++ b/lib/takuhai_status/usps.rb
@@ -7,7 +7,8 @@ module TakuhaiStatus
 		TakuhaiStatus.add_service(self)
 
 		def initialize(key)
-			@key = key.gsub(/[^a-zA-Z0-9]/, '')
+			@key = key.strip
+			raise NotMyKey.new('invalid key format') unless @key =~ /\A[a-zA-Z0-9]+\Z/
 			@time, @state = check
 		end
 


### PR DESCRIPTION
不適切なkeyが渡されたときに、正規化して処理を進めるのではなく、NotMyKey例外を返すように各サービスのクラスを修正。ただし、入力時のバリデーション不足を考慮してstripだけは内部で行う。