### PR TITLE
folow update of Sagawa

### DIFF
--- a/lib/takuhai_status/sagawa.rb
+++ b/lib/takuhai_status/sagawa.rb
@@ -1,5 +1,4 @@
-require 'faraday'
-require 'nokogiri'
+require 'mechanize'
 
 module TakuhaiStatus
 	class Sagawa
@@ -13,31 +12,34 @@ module TakuhaiStatus
 		end
 
 		def finish?
-			return !!(@state =~ /営業所へお問い合わせ下さい。|配達は終了致しました。$|^配達完了|引渡完了/)
+			return !!(@state =~ /営業所へお問い合わせください。|配達は終了致しました。$|^配達完了|引渡完了/)
 		end
 
 	private
 		def check
-			conn = Faraday.new(url: 'http://k2k.sagawa-exp.co.jp')
-			res = conn.post('/p/web/okurijosearch.do', {okurijoNo: @key})
-			doc = Nokogiri(res.body)
+			agent = Mechanize.new
+			page = agent.get('https://k2k.sagawa-exp.co.jp/p/sagawa/web/okurijoinput.jsp')
+			form = page.form_with('main')
+			form['main:no1'] = @key
+			button = form.button_with('main:toiStart')
+			result = agent.submit(form, button)
 
 			begin
-				cells = doc.css('.table_okurijo_detail2').css('tr').last.css('td')
-				state = "#{cells[0].text.strip} [#{cells[2].text.strip}]".sub(/^./, '')
-				time = Time.parse(cells[1].text.strip) rescue Time.now
-				return time, state
-			rescue NoMethodError # detail2 table not found, use detail table
-				begin
+				row = result.css('#detail1 tr')
+				cells = row[row.size - 1].css('td')
+				if cells.size == 3 #has detail
+					state = "#{cells[0].text.strip[1,100]} [#{cells[2].text.strip}]"
+					time = Time.parse(cells[1].text.strip) rescue Time.now
+				else # finished?
+					state = cells[0].text.strip
 					time = Time.now
-					state = doc.css('.table_okurijo_detail').first.css('tr').last.css('td').text.strip
-					if state =~ /恐れ入りますが、お問い合せ送り状NOをお確かめください。|お荷物データが登録されておりません。/
-						raise NotMyKey.new('invalid key')
-					end
-					return time, state
-				rescue NoMethodError
-					raise NotMyKey.new('invalid response')
 				end
+				if state =~ /恐れ入りますが、お問い合せ送り状NOをお確かめください。|お荷物データが登録されておりません。/
+					raise NotMyKey.new('invalid key')
+				end
+				return time, state
+			rescue NoMethodError
+				raise NotMyKey.new('invalid response')
 			rescue ArgumentError
 				return Time.now, ''
 			end

--- a/lib/takuhai_status/version.rb
+++ b/lib/takuhai_status/version.rb
@@ -1,3 +1,3 @@
 module TakuhaiStatus
-  VERSION = "1.8.9"
+  VERSION = "1.8.10"
 end


### PR DESCRIPTION
佐川急便の追跡フォーム更新に追従。Struts(.do)からJSF(.jsp)に変わったもよう。

* シンプルならFaradayからMechanizeを使ったページ遷移に変更
* 終了ステータスの文字列非互換に対応
* 結果テーブル解析をシンプルに