### PR TITLE
ignore error in fedex

### DIFF
--- a/lib/takuhai_status/fedex.rb
+++ b/lib/takuhai_status/fedex.rb
@@ -45,9 +45,13 @@ module TakuhaiStatus
 				format: 'json'
 			})
 
-			package = JSON.parse(res.body)["TrackPackagesResponse"]
-			unless package["successful"]
-				raise NotMyKey.new(package["errorList"].first["message"])
+			begin
+				package = JSON.parse(res.body)["TrackPackagesResponse"]
+				unless package["successful"]
+					raise NotMyKey.new(package["errorList"].first["message"])
+				end
+			rescue JSON::ParserError
+				raise NotMyKey.new('JSON parse error')
 			end
 
 			current = package["packageList"].first["scanEventList"].first


### PR DESCRIPTION
FedEx のリニューアルにともない、エラーが返ってきているので、とりあえず無視するように修正。
正規の生きた伝票が得られたら改めて修正する。